### PR TITLE
fix: advance SST index when only rich-text trailer overflows CONTINUE

### DIFF
--- a/sst_continue_test.go
+++ b/sst_continue_test.go
@@ -1,6 +1,7 @@
 package xls
 
 import (
+	"regexp"
 	"testing"
 	"unicode"
 )
@@ -68,5 +69,94 @@ func TestSSTContinueDoesNotDesync(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Regression test for a second SST CONTINUE edge case: a record may end
+// after a string's character data is complete but mid-way through its
+// trailing rgRun (rich-text format runs) or ExtRst (phonetic) bytes. The
+// loop used to break without advancing the SST index, so the next CONTINUE
+// record then wrote the *next* string onto the already-complete entry via
+// `sst[i] = sst[i] + str`, gluing two strings into one slot and shifting
+// every subsequent SST entry by one.
+//
+// In testdata/sst-error.xls this manifests at row 285: column 2 (timestamp)
+// previously held "02:38:35 PMFunds Transfer-IB\n..." (timestamp + the
+// description that should have been in column 3), with the remainder of the
+// row shifted left by one column. Post-fix, column 2 holds only the
+// timestamp and column 3 holds the description as authored.
+func TestSSTContinueTrailerOverflowDoesNotMerge(t *testing.T) {
+	wb, err := Open("testdata/sst-error.xls", "utf-8")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sheet := wb.GetSheet(0)
+	if sheet == nil {
+		t.Fatal("no sheet 0")
+	}
+
+	r := sheet.Row(285)
+	if r == nil {
+		t.Fatal("row 285 missing")
+	}
+
+	timestampRe := regexp.MustCompile(`^\d{2}:\d{2}:\d{2} (AM|PM)$`)
+
+	c2 := r.Col(2)
+	if !timestampRe.MatchString(c2) {
+		t.Errorf("row 285 col 2 should be a bare HH:MM:SS AM/PM timestamp, got %q "+
+			"— a trailing description glued on indicates the trailer-overflow "+
+			"SST merge bug has regressed", c2)
+	}
+
+	c3 := r.Col(3)
+	if c3 == "" {
+		t.Errorf("row 285 col 3 is empty — the description shifted out, "+
+			"likely re-merged into col 2 (col 2 was %q)", c2)
+	}
+	// "Funds Transfer-IB" is the literal first line of row 285's description
+	// in the source file; if the SST is shifted by one, col 3 will instead
+	// contain the next row's value ("PAYNOW-FAST\n...") or a numeric token.
+	if c3 != "" && !startsWithAny(c3, "Funds Transfer-IB", "Inward", "PAYNOW-FAST", "Bulk -", "SVC Chg", "CR Retail", "Outward") {
+		t.Errorf("row 285 col 3 = %q does not look like a transaction description; "+
+			"likely an SST shift", c3)
+	}
+
+	// Walk rows 285..320 and assert column 2 is timestamp-shaped on every row
+	// that has data. If the SST is off by one anywhere in this window, col 2
+	// will hold description text or a numeric string instead.
+	checked := 0
+	for i := 285; i <= 320; i++ {
+		rr := sheet.Row(i)
+		if rr == nil {
+			continue
+		}
+		c0 := rr.Col(0)
+		if c0 == "" {
+			// Skip header/blank rows that don't carry a transaction.
+			continue
+		}
+		c2 := rr.Col(2)
+		if c2 == "" {
+			continue
+		}
+		if !timestampRe.MatchString(c2) {
+			t.Errorf("row %d col 2 = %q is not a HH:MM:SS AM/PM timestamp; "+
+				"SST is shifted in this window", i, c2)
+		}
+		checked++
+	}
+	if checked < 30 {
+		t.Errorf("only %d rows in [285,320] had a non-empty timestamp column; "+
+			"expected ~36, suggests rows are missing", checked)
+	}
+}
+
+func startsWithAny(s string, prefixes ...string) bool {
+	for _, p := range prefixes {
+		if len(s) >= len(p) && s[:len(p)] == p {
+			return true
+		}
+	}
+	return false
 }
 

--- a/workbook.go
+++ b/workbook.go
@@ -125,6 +125,13 @@ func (wb *WorkBook) parseBof(buf io.ReadSeeker, b *bof, pre *bof, offset_pre int
 				wb.sst[offset_pre] = wb.sst[offset_pre] + str
 
 				if err == io.EOF {
+					// If only the trailer (rgRun / ExtRst) overflowed,
+					// the string itself is complete — advance so the
+					// next CONTINUE starts at the next SST slot instead
+					// of appending onto this one.
+					if wb.continue_utf16 == 0 && (wb.continue_rich > 0 || wb.continue_apsb > 0) {
+						offset_pre++
+					}
 					break
 				}
 
@@ -153,6 +160,12 @@ func (wb *WorkBook) parseBof(buf io.ReadSeeker, b *bof, pre *bof, offset_pre int
 				wb.sst[i] = wb.sst[i] + str
 			}
 			if err == io.EOF {
+				// String content complete but trailer (rgRun / ExtRst)
+				// overflowed into the next CONTINUE — advance i so the
+				// next record doesn't append onto this finished entry.
+				if wb.continue_utf16 == 0 && (wb.continue_rich > 0 || wb.continue_apsb > 0) {
+					i++
+				}
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes a second SST CONTINUE edge case missed by #2: when a record ends after a string's character data is complete but mid-way through its trailing `rgRun` (rich-text format runs) or `ExtRst` (phonetic) bytes, the parser was gluing the next string onto the already-complete entry and shifting every subsequent SST index by one.
- Adds `TestSSTContinueTrailerOverflowDoesNotMerge` — a column-shape regression test that catches the shift directly (the existing CJK heuristic cannot, since merged strings are individually well-formed ASCII).

## Background

[MS-XLS] §2.5.293 string layout:

```
[size] [flag] [optional cRun] [optional cbExtRst]
[char data: size × (1 or 2 bytes)]
[rgRun: 4 × cRun bytes]
[ExtRst: cbExtRst bytes]
```

SST records have a max byte length; overflow spills into a CONTINUE record. A split can happen at **any** byte, including between the character data and its trailing `rgRun` / `ExtRst`.

## The bug

When the split landed inside the trailer:

1. `get_string` finished writing the complete string to `sst[i]`.
2. It then hit EOF reading the trailer, set `continue_rich` (or `continue_apsb`), and returned `io.EOF`.
3. The SST loop saw `err == io.EOF` and **broke without incrementing `i`**.
4. The next CONTINUE handler correctly skipped the leftover trailer bytes (logic from #2), read the next string's size, called `get_string` for the next string, and wrote it via `sst[i] = sst[i] + str` — the **same `i`** as the previous complete string.

Result on `testdata/sst-error.xls`: `sst[1076] = "02:38:35 PM" + "Funds Transfer-IB\n..."` — two strings glued into one slot. From there every SST index is off by one and `sst[1650]` ends up empty. Row 285+ in the output reads the *next* string instead of its own, so column 2 (timestamp) shows `"02:38:35 PMFunds Transfer-IB\n..."` and the rest of the row shifts left by one.

## The fix

In both the SST handler and the CONTINUE handler in `workbook.go`, when the loop exits on EOF check whether only the trailer overflowed — `continue_utf16 == 0 && (continue_rich > 0 || continue_apsb > 0)` — and if so advance the index before breaking, so the next CONTINUE writes to a fresh slot.

## Why the existing test didn't catch this

`TestSSTContinueDoesNotDesync` asserts no CJK codepoints in column 3 (the symptom of bug #1, where ASCII bytes get misread as UTF-16). Trailer-overflow produces *individually well-formed* ASCII strings — they're just merged and shifted — so the CJK heuristic happily passed. The new test asserts column 2 matches a `HH:MM:SS AM/PM` shape across rows 285-320; without the fix it fails on 15+ rows in that window.

## Test plan

- [x] `go test -run TestSSTContinue -v` passes (both `TestSSTContinueDoesNotDesync` and the new `TestSSTContinueTrailerOverflowDoesNotMerge`).
- [x] Confirmed the new test fails reliably when the `workbook.go` change is reverted.
- [x] Row 285 of `testdata/sst-error.xls` reads `21/04/2026 | 21/04/2026 | 02:38:35 PM | Funds Transfer-IB\n... | 315.01 | 0.00 | 1,064,577.41` — schema-aligned.
- [x] Spot-checked rows 285-446 (the formerly-shifted range): timestamps, descriptions, deposit/withdrawal/balance all land in the correct columns.
- [x] Pre-existing `TestFormatParity` failure (unrelated `times.xls` rendering) is unchanged on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed spreadsheet parsing to prevent trailing metadata (formatting and phonetic data) from incorrectly merging with actual cell content, ensuring data integrity and proper record alignment.

## Tests
* Added regression test to validate correct handling of spreadsheet entries when metadata overflows during parsing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meisbokai/xls/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->